### PR TITLE
将app share开启全部替换

### DIFF
--- a/APP/NotifyIconsSupportConfig.json
+++ b/APP/NotifyIconsSupportConfig.json
@@ -173,7 +173,7 @@
     "iconBitmap": "iVBORw0KGgoAAAANSUhEUgAAADAAAAAwBAMAAAClLOS0AAAAIVBMVEVHcEz///////////////////////////////////////+PBM77AAAACnRSTlMASSy/Em7v2KaRY7oCgwAAAXJJREFUOMvNUztLw1AUTmqK6RZELHaqQkU6FV9gpopiHfvCIZN2CJhJqIJkChQUM3VwyqaheXy/0qQ35yY3zeTkmc493z2v735Xkv5uysFOZbzzYYbtivgEiQ034800XpFxBwSXo92NeM1GOK5qvIdgSr48LSRYOOGHlt/n/gBRfsvAC/ddOOTeHDYRUooMn2pOTFjg17Yxy7x7rO2BV802bqRRE1hmgE5FDfijpAeNVcOKnEArTlWnFg08Cnuo6NE6jrD5gJp1oQlEHdFQRigy2KKLHt9zrgmAG4ldOaDHGbDFgG4F4AjN9WxR6ZbNeU1sHn9JNPeQLfxcemkDbfYc3yVAZ6wodlTSDLHqQRSaih/q1StRsSS6V4Lq7SCroFgCrSriPHdWANy8ciICraDvMJeih5iLzF4/cJ7yyhDZFX+JAbwlv0Pp6MBZcUQ5CQTzxUUiuCeRhrrO1Im4/N2u3tNwcL75DZX9xennuC/9C/sFYJSEEykCAlEAAAAASUVORK5CYII=",
     "contributorName": "lamprose",
     "isEnabled": true,
-    "isEnabledAll": false
+    "isEnabledAll": true
   },
   {
     "appName": "网易云音乐",


### PR DESCRIPTION
app share在不开启全部替换前的原生通知图标很小，开启全部替换才会正常